### PR TITLE
Fix: signinWithGoogle함수의 redirectTo 주소에 locatoin.origin을 사용

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -55,7 +55,7 @@ export const signinWithGoogle = async () => {
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: 'google',
     options: {
-      redirectTo: 'http://localhost:3000/auth/callback',
+      redirectTo: `${location.origin}/auth/callback`,
       queryParams: {
         access_type: 'offline',
         prompt: 'consent',


### PR DESCRIPTION
- 배포 후에도 잘 작동하도록 redirectTo 옵션에 `${location.origin}/auth/callback`을 사용