### PR TITLE
Feat: Admin page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ shadcn/ui, Zod, React Hook Form, Supabase를 사용하여 간단한 로그인 �
 - Supabase의 Oauth를 사용하여 구글 로그인 구현
 - Next.js의 server action과 middleware를 사용하여 로그인 유지 기능 구현
 - server 컴포넌트에서 로그인 여부를 확인하여 redirect 기능 구현
+- 관리자로 로그인 시 사이트에 접속하는 모든 유저의 기본 테마를 변경하는 기능 구현
 
 ## 기술 스택
 

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -4,6 +4,8 @@ import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
+import ChangeTheme from '@/components/admin-page/ChangeTheme';
+
 import type { Database } from '@/lib/database.types';
 
 export default async function Admin() {
@@ -18,8 +20,8 @@ export default async function Admin() {
   if (!isAdmin) redirect('/');
 
   return (
-    <main className="min-h-[calc(100vh-88px)]">
-      <div>page</div>
+    <main className="min-h-[calc(100vh-88px)] flex-center">
+      <ChangeTheme adminId={session.user.id} />
     </main>
   );
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -19,6 +19,15 @@ export default async function Admin() {
   const isAdmin = session?.user.user_metadata.role === '관리자';
   if (!isAdmin) redirect('/');
 
+  const { data } = await supabase
+    .from('theme')
+    .select('theme')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  const defaultTheme = data === null ? 'system' : data.theme;
+
   return (
     <main className="min-h-[calc(100vh-88px)] flex-center">
       <ChangeTheme adminId={session.user.id} />

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+import type { Database } from '@/lib/database.types';
+
+export default async function Admin() {
+  const supabase = createServerComponentClient<Database>({ cookies });
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) redirect('/signin');
+
+  const isAdmin = session?.user.user_metadata.role === '관리자';
+  if (!isAdmin) redirect('/');
+
+  return (
+    <main className="min-h-[calc(100vh-88px)]">
+      <div>page</div>
+    </main>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -30,7 +30,7 @@ export default async function Admin() {
 
   return (
     <main className="min-h-[calc(100vh-88px)] flex-center">
-      <ChangeTheme adminId={session.user.id} />
+      <ChangeTheme defaultTheme={defaultTheme} adminId={session.user.id} />
     </main>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,8 +12,8 @@ import '@/style/globals.css';
 const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
-  title: 'dev camp',
-  description: '간단한 회원가입 페이지',
+  title: 'simple auth page',
+  description: '간단한 로그인 회원가입 페이지',
 };
 
 export default function RootLayout({

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,13 @@
+import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
 import { Inter } from 'next/font/google';
+import { cookies } from 'next/headers';
 
 import SwitchThemeButton from '@/components/buttons/switchTheme/SwitchThemeButton';
 import Header from '@/components/header/Header';
 import NextThemesProvider from '@/components/providers/NextThemesProvider';
 import { Toaster } from '@/components/ui/toaster';
 
+import type { Database } from '@/lib/database.types';
 import type { Metadata } from 'next';
 
 import '@/style/globals.css';
@@ -16,11 +19,21 @@ export const metadata: Metadata = {
   description: '간단한 로그인 회원가입 페이지',
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const supabase = createServerComponentClient<Database>({ cookies });
+  const { data } = await supabase
+    .from('theme')
+    .select('theme')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  const defaultTheme = data === null ? 'system' : data.theme;
+
   return (
     <html lang="en">
       <body className={inter.className}>
@@ -33,7 +46,7 @@ export default function RootLayout({
           <Header />
           {children}
           <Toaster />
-          <SwitchThemeButton />
+          <SwitchThemeButton defaultTheme={defaultTheme} />
         </NextThemesProvider>
       </body>
     </html>

--- a/components/admin-page/ChangeTheme.tsx
+++ b/components/admin-page/ChangeTheme.tsx
@@ -2,6 +2,8 @@
 
 import React from 'react';
 
+import { useRouter } from 'next/navigation';
+
 import { changeRawTheme } from '@/lib/admin';
 
 import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group';
@@ -9,17 +11,26 @@ import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group';
 import type { Themes } from '@/lib/admin';
 
 interface ChangeThemeProps {
+  defaultTheme: string;
   adminId: string;
 }
 
-const ChangeTheme = ({ adminId }: ChangeThemeProps) => {
+const ChangeTheme = ({ defaultTheme, adminId }: ChangeThemeProps) => {
+  const router = useRouter();
+
   const onClickTheme = async (theme: Themes) => {
     await changeRawTheme(theme, adminId);
+    router.refresh();
   };
 
   return (
-    <ToggleGroup variant={'outline'} type="single">
-      <ToggleGroupItem value="bold" aria-label="Toggle light">
+    <ToggleGroup
+      variant={'outline'}
+      type="single"
+      defaultValue={defaultTheme}
+      defaultChecked
+    >
+      <ToggleGroupItem value="light" aria-label="Toggle light">
         <p onClick={() => onClickTheme('light')}>light</p>
       </ToggleGroupItem>
       <ToggleGroupItem value="dark" aria-label="Toggle dark">

--- a/components/admin-page/ChangeTheme.tsx
+++ b/components/admin-page/ChangeTheme.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 
 import { changeRawTheme } from '@/lib/admin';
 
+import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group';
+
 import type { Themes } from '@/lib/admin';
 
 interface ChangeThemeProps {
@@ -16,11 +18,17 @@ const ChangeTheme = ({ adminId }: ChangeThemeProps) => {
   };
 
   return (
-    <div className="flex flex-col">
-      <button onClick={() => onClickTheme('light')}>light</button>
-      <button onClick={() => onClickTheme('dark')}>dark</button>
-      <button onClick={() => onClickTheme('system')}>system</button>
-    </div>
+    <ToggleGroup variant={'outline'} type="single">
+      <ToggleGroupItem value="bold" aria-label="Toggle light">
+        <p onClick={() => onClickTheme('light')}>light</p>
+      </ToggleGroupItem>
+      <ToggleGroupItem value="dark" aria-label="Toggle dark">
+        <p onClick={() => onClickTheme('dark')}>dark</p>
+      </ToggleGroupItem>
+      <ToggleGroupItem value="system" aria-label="Toggle system">
+        <p onClick={() => onClickTheme('system')}>system</p>
+      </ToggleGroupItem>
+    </ToggleGroup>
   );
 };
 

--- a/components/admin-page/ChangeTheme.tsx
+++ b/components/admin-page/ChangeTheme.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import React from 'react';
+
+import { changeRawTheme } from '@/lib/admin';
+
+import type { Themes } from '@/lib/admin';
+
+interface ChangeThemeProps {
+  adminId: string;
+}
+
+const ChangeTheme = ({ adminId }: ChangeThemeProps) => {
+  const onClickTheme = async (theme: Themes) => {
+    await changeRawTheme(theme, adminId);
+  };
+
+  return (
+    <div className="flex flex-col">
+      <button onClick={() => onClickTheme('light')}>light</button>
+      <button onClick={() => onClickTheme('dark')}>dark</button>
+      <button onClick={() => onClickTheme('system')}>system</button>
+    </div>
+  );
+};
+
+export default ChangeTheme;

--- a/components/admin-page/ChangeTheme.tsx
+++ b/components/admin-page/ChangeTheme.tsx
@@ -24,22 +24,25 @@ const ChangeTheme = ({ defaultTheme, adminId }: ChangeThemeProps) => {
   };
 
   return (
-    <ToggleGroup
-      variant={'outline'}
-      type="single"
-      defaultValue={defaultTheme}
-      defaultChecked
-    >
-      <ToggleGroupItem value="light" aria-label="Toggle light">
-        <p onClick={() => onClickTheme('light')}>light</p>
-      </ToggleGroupItem>
-      <ToggleGroupItem value="dark" aria-label="Toggle dark">
-        <p onClick={() => onClickTheme('dark')}>dark</p>
-      </ToggleGroupItem>
-      <ToggleGroupItem value="system" aria-label="Toggle system">
-        <p onClick={() => onClickTheme('system')}>system</p>
-      </ToggleGroupItem>
-    </ToggleGroup>
+    <section className="flex flex-col gap-5">
+      <h3>사용자들의 기본 테마를 바꿀 수 있습니다.</h3>
+      <ToggleGroup
+        variant={'outline'}
+        type="single"
+        defaultValue={defaultTheme}
+        defaultChecked
+      >
+        <ToggleGroupItem value="light" aria-label="Toggle light">
+          <p onClick={() => onClickTheme('light')}>light</p>
+        </ToggleGroupItem>
+        <ToggleGroupItem value="dark" aria-label="Toggle dark">
+          <p onClick={() => onClickTheme('dark')}>dark</p>
+        </ToggleGroupItem>
+        <ToggleGroupItem value="system" aria-label="Toggle system">
+          <p onClick={() => onClickTheme('system')}>system</p>
+        </ToggleGroupItem>
+      </ToggleGroup>
+    </section>
   );
 };
 

--- a/components/buttons/switchTheme/SwitchThemeButton.tsx
+++ b/components/buttons/switchTheme/SwitchThemeButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { Moon, Sun } from 'lucide-react';
 import { useTheme } from 'next-themes';
@@ -13,8 +13,18 @@ import {
   DropdownMenuTrigger,
 } from '../../ui/dropdown';
 
-const SwitchThemeButton = () => {
+interface SwitchThemeButtonProps {
+  defaultTheme?: string;
+}
+
+const SwitchThemeButton = ({ defaultTheme }: SwitchThemeButtonProps) => {
   const { setTheme } = useTheme();
+
+  useEffect(() => {
+    if (defaultTheme) {
+      setTheme(defaultTheme);
+    }
+  }, [defaultTheme]);
 
   return (
     <DropdownMenu>

--- a/components/nav/Nav.tsx
+++ b/components/nav/Nav.tsx
@@ -19,6 +19,7 @@ interface NavProps {
 const Nav = ({ session }: NavProps) => {
   const router = useRouter();
   const isLogin = session !== null;
+  const isAdmin = session?.user.user_metadata.role === '관리자';
 
   const onClickLogout = async () => {
     await signout();
@@ -32,6 +33,7 @@ const Nav = ({ session }: NavProps) => {
         {isLogin ? (
           <>
             <NavLinkItem href="/" value="홈" />
+            {isAdmin && <NavLinkItem href="/admin" value="관리" />}
             <NavButtonItem value="로그아웃" onClick={onClickLogout} />
           </>
         ) : (

--- a/components/ui/toggle-group.tsx
+++ b/components/ui/toggle-group.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import * as React from "react"
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group"
+import { VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/components/ui/toggle"
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants>
+>({
+  size: "default",
+  variant: "default",
+})
+
+const ToggleGroup = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
+    VariantProps<typeof toggleVariants>
+>(({ className, variant, size, children, ...props }, ref) => (
+  <ToggleGroupPrimitive.Root
+    ref={ref}
+    className={cn("flex items-center justify-center gap-1", className)}
+    {...props}
+  >
+    <ToggleGroupContext.Provider value={{ variant, size }}>
+      {children}
+    </ToggleGroupContext.Provider>
+  </ToggleGroupPrimitive.Root>
+))
+
+ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName
+
+const ToggleGroupItem = React.forwardRef<
+  React.ElementRef<typeof ToggleGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
+    VariantProps<typeof toggleVariants>
+>(({ className, children, variant, size, ...props }, ref) => {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <ToggleGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  )
+})
+
+ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName
+
+export { ToggleGroup, ToggleGroupItem }

--- a/components/ui/toggle.tsx
+++ b/components/ui/toggle.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import * as React from "react"
+import * as TogglePrimitive from "@radix-ui/react-toggle"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-10 px-3",
+        sm: "h-9 px-2.5",
+        lg: "h-11 px-5",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+const Toggle = React.forwardRef<
+  React.ElementRef<typeof TogglePrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> &
+    VariantProps<typeof toggleVariants>
+>(({ className, variant, size, ...props }, ref) => (
+  <TogglePrimitive.Root
+    ref={ref}
+    className={cn(toggleVariants({ variant, size, className }))}
+    {...props}
+  />
+))
+
+Toggle.displayName = TogglePrimitive.Root.displayName
+
+export { Toggle, toggleVariants }

--- a/lib/admin.ts
+++ b/lib/admin.ts
@@ -1,0 +1,6 @@
+import { supabase } from './auth';
+
+export const changeRawTheme = async (theme: string) => {
+  const { data, error } = await supabase.from('theme').insert({ theme });
+  console.log(data, error);
+};

--- a/lib/admin.ts
+++ b/lib/admin.ts
@@ -1,6 +1,10 @@
 import { supabase } from './auth';
 
-export const changeRawTheme = async (theme: string) => {
-  const { data, error } = await supabase.from('theme').insert({ theme });
+export type Themes = 'light' | 'dark' | 'system';
+
+export const changeRawTheme = async (theme: Themes, admin_id: string) => {
+  const { data, error } = await supabase
+    .from('theme')
+    .insert({ theme, admin_id });
   console.log(data, error);
 };

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -1,5 +1,3 @@
-import type { Database } from 'lucide-react';
-
 export type Json =
   | string
   | number
@@ -11,6 +9,24 @@ export type Json =
 export type Database = {
   public: {
     Tables: {
+      theme: {
+        Row: {
+          created_at: string;
+          id: string;
+          theme: string;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          theme: string;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          theme?: string;
+        };
+        Relationships: [];
+      };
       users: {
         Row: {
           created_at: string;

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -11,16 +11,19 @@ export type Database = {
     Tables: {
       theme: {
         Row: {
+          admin_id: string;
           created_at: string;
           id: string;
           theme: string;
         };
         Insert: {
+          admin_id?: string;
           created_at?: string;
           id?: string;
           theme: string;
         };
         Update: {
+          admin_id?: string;
           created_at?: string;
           id?: string;
           theme?: string;

--- a/lib/token.ts
+++ b/lib/token.ts
@@ -1,1 +1,0 @@
-const secret = process.env.NEXT_PUBLIC_JWT_SECRET as string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-toast": "^1.1.5",
+        "@radix-ui/react-toggle": "^1.0.3",
+        "@radix-ui/react-toggle-group": "^1.0.4",
         "@supabase/auth-helpers-nextjs": "^0.9.0",
         "@supabase/supabase-js": "^2.39.7",
         "class-variance-authority": "^0.7.0",
@@ -1104,6 +1106,60 @@
         "@radix-ui/react-use-controllable-state": "1.0.1",
         "@radix-ui/react-use-layout-effect": "1.0.1",
         "@radix-ui/react-visually-hidden": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.0.3.tgz",
+      "integrity": "sha512-Pkqg3+Bc98ftZGsl60CLANXQBBQ4W3mTFS9EJvNxKMZ7magklKV69/id1mlAlOFDDfHvlCms0fx8fA4CMKDJHg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.0.4.tgz",
+      "integrity": "sha512-Uaj/M/cMyiyT9Bx6fOZO0SAG4Cls0GptBWiBmBxofmDbNVnYYoyRWj/2M/6VCi/7qcXFWnHhRUfdfZFvvkuu8A==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-roving-focus": "1.0.4",
+        "@radix-ui/react-toggle": "1.0.3",
+        "@radix-ui/react-use-controllable-state": "1.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-toast": "^1.1.5",
+    "@radix-ui/react-toggle": "^1.0.3",
+    "@radix-ui/react-toggle-group": "^1.0.4",
     "@supabase/auth-helpers-nextjs": "^0.9.0",
     "@supabase/supabase-js": "^2.39.7",
     "class-variance-authority": "^0.7.0",


### PR DESCRIPTION
- 관리자로 로그인 시 nav에 관리 메뉴 표시
- 관리자 페이지에서 사이트 자체 기본 테마를 변경하는 기능 구현
- supabase의 theme table의 RLP로 insert 하는 유저의 role이 관리자일 때 insert 가능하도록 변경
- rootlayout 컴포넌트에서 제일 최근에 설정된 기본 테마를 불러와 SwitchThemeButton에게 props로 전달, SwitchThemeButton에서 useEffect로 테마를 변경